### PR TITLE
fixes github pages 404 on refresh by using hash router instead of browser router

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 //import React from "react";
 import { useEffect } from "react";
 import {
-    BrowserRouter as Router,
+    HashRouter as Router,
     Routes,
     Route,
     Navigate,
@@ -37,7 +37,7 @@ function App() {
 
     return (
         <ThemeProvider>
-            <Router basename={import.meta.env.VITE_BASE_URL || '/'}>
+            <Router>
                 <Routes>
                     <Route path="/" element={<Navigate to="/Home" />} />
                     <Route path="/Home" element={<Home />} />


### PR DESCRIPTION
## Description
<!-- Please describe your changes here
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. -->
This PR fixes the GitHub Pages deployments by replacing the browser router with the hash router, which allows GitHub to handle subpaths like `/Home`. I've already tested the deployment and this works.

## What type of change is this?
<!-- Mark all options that are valid -->
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Style
- [ ] Refactor
- [ ] Test
- [ ] Revert

## Checklist before requesting review
<!-- Checklist -->
- [x] I have self-reviewed my code
- [x] I have successfully tested my code locally
- [x] If changing a feature, have you explained your change?

## Added Tests?
<!-- Are tests necessary? -->
- [ ] Yes
- [x] No, not necessary

##  Screenshots
<!-- Add screenshots if relevant -->

## Relevant documents
<!-- If there are relevant Figma, Google Docs, etc., link them here -->